### PR TITLE
Add Docker image publishing work

### DIFF
--- a/.github/workflows/docker_72_build.yml
+++ b/.github/workflows/docker_72_build.yml
@@ -1,9 +1,6 @@
 name: Docker build
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/docker_72_publish.yml
+++ b/.github/workflows/docker_72_publish.yml
@@ -1,0 +1,31 @@
+name: Docker publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build Docker 7.2 image
+        run: cd 7.2/cli && docker build -t 7.2 .
+      - name: Build Docker 7.2-fpm image
+        run: cd 7.2/fpm && docker build -t 7.2-fpm .
+      - name: Tags 7.2
+        run: |
+          docker tag 7.2 ${{ secrets.DOCKER_USER }}/laravel:7.2
+      - name: Publish Docker 7.2 image
+        run: |
+          docker push ${{ secrets.DOCKER_USER }}/laravel:7.2
+      - name: Tags 7.2-fpm
+        run: |
+          docker tag 7.2-fpm ${{ secrets.DOCKER_USER }}/laravel:7.2-fpm
+      - name: Publish Docker 7.2-fpm image
+        run: |
+          docker push ${{ secrets.DOCKER_USER }}/laravel:7.2-fpm

--- a/.github/workflows/docker_73_build.yml
+++ b/.github/workflows/docker_73_build.yml
@@ -1,9 +1,6 @@
 name: Docker build
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/docker_73_publish.yml
+++ b/.github/workflows/docker_73_publish.yml
@@ -1,0 +1,31 @@
+name: Docker publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build Docker 7.3 image
+        run: cd 7.3/cli && docker build -t 7.3 .
+      - name: Build Docker 7.3-fpm image
+        run: cd 7.3/fpm && docker build -t 7.3-fpm .
+      - name: Tags 7.3
+        run: |
+          docker tag 7.3 ${{ secrets.DOCKER_USER }}/laravel:7.3
+      - name: Publish Docker 7.3 image
+        run: |
+          docker push ${{ secrets.DOCKER_USER }}/laravel:7.3
+      - name: Tags 7.3-fpm
+        run: |
+          docker tag 7.3-fpm ${{ secrets.DOCKER_USER }}/laravel:7.3-fpm
+      - name: Publish Docker 7.3-fpm image
+        run: |
+          docker push ${{ secrets.DOCKER_USER }}/laravel:7.3-fpm

--- a/.github/workflows/docker_74_build.yml
+++ b/.github/workflows/docker_74_build.yml
@@ -1,9 +1,6 @@
 name: Docker build
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/docker_74_publish.yml
+++ b/.github/workflows/docker_74_publish.yml
@@ -1,0 +1,31 @@
+name: Docker publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build Docker 7.4 image
+        run: cd 7.4/cli && docker build -t 7.4 .
+      - name: Build Docker 7.4-fpm image
+        run: cd 7.4/fpm && docker build -t 7.4-fpm .
+      - name: Tags 7.4
+        run: |
+          docker tag 7.4 ${{ secrets.DOCKER_USER }}/laravel:7.4
+      - name: Publish Docker 7.4 image
+        run: |
+          docker push ${{ secrets.DOCKER_USER }}/laravel:7.4
+      - name: Tags 7.4-fpm
+        run: |
+          docker tag 7.4-fpm ${{ secrets.DOCKER_USER }}/laravel:7.4-fpm
+      - name: Publish Docker 7.4-fpm image
+        run: |
+          docker push ${{ secrets.DOCKER_USER }}/laravel:7.4-fpm


### PR DESCRIPTION
# Changed log

- Adding the Docker image publishing work with `push` trigger on GitHub Actions.
- Adding the `DOCKER_USER` and `DOCKER_PASSWORD` repository secrets on repository setting to login the Docker Hub.
- Adding the Docker image building work with `pull_request` trigger on GitHub Actions.